### PR TITLE
Avoid forced linking as a side effect of find_package

### DIFF
--- a/FindLibXAIE.cmake
+++ b/FindLibXAIE.cmake
@@ -47,9 +47,3 @@ find_package_handle_standard_args(LibXAIE
   FOUND_VAR LibXAIE_FOUND
   REQUIRED_VARS XILINX_XAIE_INCLUDE_DIR XILINX_XAIE_LIBS
   )
-
-if(LibXAIE_FOUND)
-add_compile_definitions(AIE_LIBXAIE_ENABLE)
-include_directories(${XILINX_XAIE_INCLUDE_DIR})
-link_libraries(${XILINX_XAIE_LIBS})
-endif()


### PR DESCRIPTION
`find_package(LibXAIE)` has the side effect of adding libxaie to the include path and link libraries. This is undesirable because it means the calling cmake file is not in control of which binaries are linked against libxaie. As an example, if `find_package` is used at the top level, then all binaries will get linked against libxaie even if it's appropriate for only a subset. Instead, the user of FindLibXAIE should be in charge of when to say `link_libraries(${XILINX_XAIE_LIBS})`.  This change impacts downstream users (in a good way).