### PR TITLE
black format python files

### DIFF
--- a/unittests/lit-test.py
+++ b/unittests/lit-test.py
@@ -9,5 +9,6 @@
 # (c) Copyright 2021 Xilinx Inc.
 
 from lit.main import main
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/unittests/lit.cfg.py
+++ b/unittests/lit.cfg.py
@@ -14,26 +14,34 @@ import tempfile
 
 import lit.formats
 import lit.util
-#from lit.llvm import llvm_config
-  
+
+# from lit.llvm import llvm_config
+
 config.name = "CMake LIT test"
 config.test_format = lit.formats.ShTest(True)
-config.test_source_root = os.path.join(os.path.dirname(__file__), 'findTests')
+config.test_source_root = os.path.join(os.path.dirname(__file__), "findTests")
 if not hasattr(config, "test_exec_root"):
     config.test_exec_root = os.path.join(os.path.dirname(__file__))
 
-cmake_root = os.path.join(os.path.dirname(__file__), '..')
+cmake_root = os.path.join(os.path.dirname(__file__), "..")
 
 if not hasattr(config, "cmake_opts"):
     config.cmake_opts = ""
-config.substitutions.append(('%cmake', 'cmake -DCMAKE_MODULE_PATH=' + cmake_root + ' -DCMAKE_FIND_LIBRARY_PREFIXES=lib -DCMAKE_FIND_LIBRARY_SUFFIXES=".a;.so" ' + config.cmake_opts))
+config.substitutions.append(
+    (
+        "%cmake",
+        "cmake -DCMAKE_MODULE_PATH="
+        + cmake_root
+        + ' -DCMAKE_FIND_LIBRARY_PREFIXES=lib -DCMAKE_FIND_LIBRARY_SUFFIXES=".a;.so" '
+        + config.cmake_opts,
+    )
+)
 
 if hasattr(config, "disable_checks"):
-    config.substitutions.append(('%grep', "echo")) 
+    config.substitutions.append(("%grep", "echo"))
 else:
-    config.substitutions.append(('%grep', "grep")) 
+    config.substitutions.append(("%grep", "grep"))
 
-#config.substitutions.append(('%vitis_root%', config.vitis_root)) 
+# config.substitutions.append(('%vitis_root%', config.vitis_root))
 
-config.suffixes = ['.cmake']
-
+config.suffixes = [".cmake"]


### PR DESCRIPTION
NFC, just trying to prevent downstream format checks from failing.

for example,
https://github.com/Xilinx/mlir-aie/actions/runs/8694236748/job/23842711802?pr=1248#step:9:15