### PR TITLE
Find chesscc binary for AIE targets

### DIFF
--- a/FindAIETools.cmake
+++ b/FindAIETools.cmake
@@ -151,11 +151,9 @@ foreach(comp ${AIETools_FIND_COMPONENTS})
 		set(aieVersionTargetPath "target")
 	elseif(${comp} STREQUAL "AIE2")
 		set(aieVersionTargetPath "target_aie_ml")
-	elseif(${comp} STREQUAL "AIE2P")
-		set(aieVersionTargetPath "target_aie2p")
 	else()
-		message(ERROR "${comp} not supported")
-		set(aieVersionTargetPath "unknown")
+		string(TOLOWER ${comp} aiearch)
+		set(aieVersionTargetPath "target_${aiearch}")
 	endif()
 
 	# Find chesscc

--- a/FindAIETools.cmake
+++ b/FindAIETools.cmake
@@ -147,6 +147,26 @@ foreach(comp ${AIETools_FIND_COMPONENTS})
 		set(aieVersionSpecificPath "unknown")
 	endif()
 
+	if(${comp} STREQUAL "AIE")
+		set(aieVersionTargetPath "target")
+	elseif(${comp} STREQUAL "AIE2")
+		set(aieVersionTargetPath "target_aie_ml")
+	elseif(${comp} STREQUAL "AIE2P")
+		set(aieVersionTargetPath "target_aie2p")
+	else()
+		message(ERROR "${comp} not supported")
+		set(aieVersionTargetPath "unknown")
+	endif()
+
+	# Find chesscc
+	find_path(AIETOOLS_${comp}_CHESSCC "chesscc" PATHS ${AIETOOLS_DIR}/tps/lnx64/${aieVersionTargetPath}/bin/LNa64bin
+			NO_DEFAULT_PATH CMAKE_FIND_ROOT_PATH_BOTH)
+	if(NOT AIETOOLS_${comp}_CHESSCC)
+		message(STATUS "Unable to find ${comp} chesscc")
+	else(NOT AIETOOLS_${comp}_CHESSCC)
+		message(STATUS "Found ${comp} chesscc: ${AIETOOLS_${comp}_CHESSCC}")
+	endif(NOT AIETOOLS_${comp}_CHESSCC)
+
 	# Find aie_core.h
 	find_path(AIETOOLS_${comp}_INCLUDE_DIR "aie_core.h" PATHS ${AIETOOLS_DIR}/data/${aieVersionSpecificPath}/lib
 			NO_DEFAULT_PATH CMAKE_FIND_ROOT_PATH_BOTH)
@@ -203,7 +223,7 @@ foreach(comp ${AIETools_FIND_COMPONENTS})
 	endif(NOT AIETOOLS_${comp}_LIBSOFTFLOAT)
 
 	#find_package(AIETools${comp})
-	if (AIETOOLS_${comp}_INCLUDE_DIR AND AIETOOLS_${comp}_LIBME AND AIETOOLS_${comp}_LIBC AND AIETOOLS_${comp}_LIBM AND AIETOOLS_${comp}_RUNTIME_INCLUDE_DIR AND AIETOOLS_${comp}_LIBSOFTFLOAT)
+	if (AIETOOLS_${comp}_INCLUDE_DIR AND AIETOOLS_${comp}_LIBME AND AIETOOLS_${comp}_LIBC AND AIETOOLS_${comp}_LIBM AND AIETOOLS_${comp}_RUNTIME_INCLUDE_DIR AND AIETOOLS_${comp}_LIBSOFTFLOAT AND AIETOOLS_${comp}_CHESSCC)
 		set(AIETools_${comp}_FOUND TRUE)
 	endif()
 

--- a/FindAIETools.cmake
+++ b/FindAIETools.cmake
@@ -159,13 +159,13 @@ foreach(comp ${AIETools_FIND_COMPONENTS})
 	endif()
 
 	# Find chesscc
-	find_path(AIETOOLS_${comp}_CHESSCC "chesscc" PATHS ${AIETOOLS_DIR}/tps/lnx64/${aieVersionTargetPath}/bin/LNa64bin
+	find_path(AIETOOLS_${comp}_TARGET_DIR "chesscc" PATHS ${AIETOOLS_DIR}/tps/lnx64/${aieVersionTargetPath}/bin/LNa64bin
 			NO_DEFAULT_PATH CMAKE_FIND_ROOT_PATH_BOTH)
-	if(NOT AIETOOLS_${comp}_CHESSCC)
-		message(STATUS "Unable to find ${comp} chesscc")
-	else(NOT AIETOOLS_${comp}_CHESSCC)
-		message(STATUS "Found ${comp} chesscc: ${AIETOOLS_${comp}_CHESSCC}")
-	endif(NOT AIETOOLS_${comp}_CHESSCC)
+	if(NOT AIETOOLS_${comp}_TARGET_DIR)
+		message(STATUS "Unable to find ${comp} target dir")
+	else(NOT AIETOOLS_${comp}_TARGET_DIR)
+		message(STATUS "Found ${comp} target dir: ${AIETOOLS_${comp}_TARGET_DIR}")
+	endif(NOT AIETOOLS_${comp}_TARGET_DIR)
 
 	# Find aie_core.h
 	find_path(AIETOOLS_${comp}_INCLUDE_DIR "aie_core.h" PATHS ${AIETOOLS_DIR}/data/${aieVersionSpecificPath}/lib
@@ -223,7 +223,7 @@ foreach(comp ${AIETools_FIND_COMPONENTS})
 	endif(NOT AIETOOLS_${comp}_LIBSOFTFLOAT)
 
 	#find_package(AIETools${comp})
-	if (AIETOOLS_${comp}_INCLUDE_DIR AND AIETOOLS_${comp}_LIBME AND AIETOOLS_${comp}_LIBC AND AIETOOLS_${comp}_LIBM AND AIETOOLS_${comp}_RUNTIME_INCLUDE_DIR AND AIETOOLS_${comp}_LIBSOFTFLOAT AND AIETOOLS_${comp}_CHESSCC)
+	if (AIETOOLS_${comp}_INCLUDE_DIR AND AIETOOLS_${comp}_LIBME AND AIETOOLS_${comp}_LIBC AND AIETOOLS_${comp}_LIBM AND AIETOOLS_${comp}_RUNTIME_INCLUDE_DIR AND AIETOOLS_${comp}_LIBSOFTFLOAT AND AIETOOLS_${comp}_TARGET_DIR)
 		set(AIETools_${comp}_FOUND TRUE)
 	endif()
 


### PR DESCRIPTION
This enables additional checking for necessary components (`chesscc`) before setting the `AIETools_AIE_FOUND` variable for example