### PR TITLE
Remove REQUIRED from find_path for AIETOOLS_INCLUDE_DIR

### DIFF
--- a/FindAIETools.cmake
+++ b/FindAIETools.cmake
@@ -131,7 +131,7 @@ endif(NOT AIETOOLS_XCHESSCC)
 #  1) dirname(`which xchesscc`)/../include which is the Vitis install path
 #  2) $ENV{SITE_PACKAGES}/include which is the RyzenAI Software install path
 find_path(AIETOOLS_INCLUDE_DIR "adf.h"
-		PATHS ${_aietools_dir}/include $ENV{SITE_PACKAGES}/include REQUIRED)
+		PATHS ${_aietools_dir}/include $ENV{SITE_PACKAGES}/include)
 if(NOT AIETOOLS_INCLUDE_DIR)
 	message(STATUS "Unable to find aietools directory")
 else()


### PR DESCRIPTION
Remove REQUIRED from the include dir search so that not having it does not cause an error at this level. The user of FindAIETools.cmake should decide what is required. I did not test #30 without aietools and this caused errors in mlir-aie CI for actions without aietools.